### PR TITLE
Allow leading zeros for stop_code

### DIFF
--- a/curlbus/server.py
+++ b/curlbus/server.py
@@ -68,7 +68,7 @@ class CurlbusServer(object):
                                        config["mot"]["user_id"])
         db.init_app(app)
         app.router.add_static("/static/", os.path.join(os.path.dirname(__file__), '..', "static"))
-        app.add_routes([web.get('/{stop_code:\d+}{tail:/*}', self.handle_station),
+        app.add_routes([web.get('/0*{stop_code:\d+}{tail:/*}', self.handle_station),
                         web.get('/operators{tail:/*}', self.handle_operator_index),
                         web.get('/nearby', self.handle_nearby),
                         web.get('/{operator:\w+}{tail:/*}', self.handle_operator),


### PR DESCRIPTION
This solves the problem of stop codes being of length 5 on stop signs even when represented by integers of four digits. For example, requesting `https://curlbus.app/01836` results in an "Invalid stop code" error.

This small untested change should solve this problem by allowing an arbitrary number of zeroes as the prefix of a `stop_code`.

Thanks again for this great app.