### PR TITLE
Fix because FTP method has been deprated

### DIFF
--- a/update_feed.sh
+++ b/update_feed.sh
@@ -5,7 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 pushd ${DIR}
     POSTGRES_DSN="$(python3 -c 'import configparser; c = configparser.ConfigParser(); c.read("config.ini"); print(c["gino"]["dsn"])')"
-    wget ftp://gtfs.mot.gov.il/israel-public-transportation.zip -O israel-public-transportation.zip
+    wget --no-check-certificate https://gtfs.mot.gov.il/gtfsfiles/israel-public-transportation.zip -O israel-public-transportation.zip
     python3 create_tables.py
     TEMP_DIR="$(mktemp -d)"
     unzip israel-public-transportation.zip -d "$TEMP_DIR"


### PR DESCRIPTION
See note in this PDF:
https://www.gov.il/BlobFolder/generalpage/gtfs_general_transit_feed_specifications/he/GTFS_Developer_Information_2022.07.27.pdf

> The files are transferred every night to the site: https://gtfs.mot.gov.il/gtfsfiles
1.9 The files are also at FTP ftp://gtfs.mot.gov.il and ftp://199.203.58.18 but
these services are due to be shut down at 31/12/2022, and only the
HTTPS will be available in the future